### PR TITLE
Add some debug implementations.

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 mod errors;
 mod tcp_listener;
 mod tcp_stream;
@@ -24,6 +26,7 @@ mod stdlib {
     }
 }
 
+#[derive(Debug)]
 pub struct SocketAddrIterator {
     resolver_id: u32,
 }

--- a/src/net/tcp_listener.rs
+++ b/src/net/tcp_listener.rs
@@ -41,10 +41,12 @@ mod stdlib {
 /// use lunatic::net::TcpListener;
 ///
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TcpListener {
     inner: Rc<TcpListenerInner>,
 }
+
+#[derive(Debug)]
 pub struct TcpListenerInner {
     id: u32,
 }
@@ -122,7 +124,7 @@ impl Serialize for TcpListener {
     }
 }
 
-struct TcpListenerVisitor {}
+struct TcpListenerVisitor;
 
 impl<'de> Visitor<'de> for TcpListenerVisitor {
     type Value = TcpListener;
@@ -145,6 +147,6 @@ impl<'de> Deserialize<'de> for TcpListener {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_u32(TcpListenerVisitor {})
+        deserializer.deserialize_u32(TcpListenerVisitor)
     }
 }

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -54,10 +54,12 @@ mod stdlib {
 /// The Transmission Control Protocol is specified in [IETF RFC 793].
 ///
 /// [IETF RFC 793]: https://tools.ietf.org/html/rfc793
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TcpStream {
     inner: Rc<TcpStreamInner>,
 }
+
+#[derive(Debug)]
 pub struct TcpStreamInner {
     id: u32,
 }


### PR DESCRIPTION
I don't know whether it's correct for these to output the underlying "pointer" values, but I think having an implementation (even if it just debugs the struct name) is helpful for when trying to derive `Debug` on a struct containing one of these items.