### PR TITLE
Add a `#[must_use]` warning for `Process`es.

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -25,6 +25,8 @@ mod stdlib {
 ///
 /// Dropping a `Process` cancels it. To drop the Task handle without canceling it, use `detach()`
 /// instead.
+#[must_use = "`Process`es are cancelled when they are dropped. To avoid dropping this process
+immediately, you should use it (e.g. by calling `Process::detach` or `Process::join`)."]
 pub struct Process {
     id: u32,
 }


### PR DESCRIPTION
I think this is correct, but I'm not 100% sure.