### PR TITLE
Fix recursive_count test failing

### DIFF
--- a/tests/process.rs
+++ b/tests/process.rs
@@ -51,7 +51,9 @@ fn mailbox_timeout(m: Mailbox<i32>) {
 
 #[test]
 fn recursive_count(mailbox: Mailbox<i32>) {
-    Process::spawn_link((mailbox.this(), 1000), recursive_count_sub);
+    let mut config = ProcessConfig::new();
+    config.set_can_spawn_processes(true);
+    Process::spawn_link_config(&config, (mailbox.this(), 1000), recursive_count_sub);
     assert_eq!(500500, mailbox.receive());
 }
 

--- a/tests/task.rs
+++ b/tests/task.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use lunatic::{sleep, spawn_link};
+use lunatic::{sleep, spawn_link, ProcessConfig};
 use lunatic_test::test;
 
 #[test]
@@ -25,7 +25,9 @@ fn result_must_be_called() {
 
 #[test]
 fn recursive_count() {
-    let task = spawn_link!(@task |n = 1_000| recursive_count_sub(n));
+    let mut config = ProcessConfig::new();
+    config.set_can_spawn_processes(true);
+    let task = spawn_link!(@task &config, |n = 1_000| recursive_count_sub(n));
     assert_eq!(500500, task.result());
 }
 


### PR DESCRIPTION
Temporary fix for https://github.com/lunatic-solutions/lunatic/issues/104

This fix prevents the runtime from creating too many file descriptors by clearing the preopen_dir array for child processes.

- [x] all tests passed 