### PR TITLE
net::UdpSocket bind, local_addr

### DIFF
--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -60,8 +60,18 @@ pub mod networking {
             scope_id: u32,
             id: *mut u64,
         ) -> u32;
+        pub fn udp_bind(
+            addr_type: u32,
+            addr: *const u8,
+            port: u32,
+            flow_info: u32,
+            scope_id: u32,
+            id: *mut u64
+        ) -> u32;
         pub fn drop_tcp_listener(tcp_listener_id: u64);
+        pub fn drop_udp_socket(udp_socket_id: u64);
         pub fn tcp_local_addr(tcp_listener_id: u64, addr_dns_iter: *mut u64) -> u32;
+        pub fn udp_local_addr(udp_socket_id: u64, addr_dns_iter: *mut u64) -> u32;        
         pub fn tcp_accept(listener_id: u64, id: *mut u64, peer_dns_iter: *mut u64) -> u32;
         pub fn tcp_connect(
             addr_type: u32,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,6 +3,7 @@
 mod resolver;
 mod tcp_listener;
 mod tcp_stream;
+mod udp;
 
 use std::io::{Error, ErrorKind, Result};
 use std::iter::Cloned;
@@ -13,6 +14,7 @@ use std::slice::Iter;
 pub use resolver::{resolve, resolve_timeout, SocketAddrIterator};
 pub use tcp_listener::TcpListener;
 pub use tcp_stream::TcpStream;
+pub use udp::UdpSocket;
 
 /// A trait for objects which can be converted or resolved to one or more
 /// [`SocketAddr`] values.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,0 +1,89 @@
+use std::io::{Error, ErrorKind, Result};
+use std::net::SocketAddr;
+
+use super::SocketAddrIterator;
+use crate::{error::LunaticError, host};
+
+#[derive(Debug)]
+pub struct UdpSocket {
+    id: u64,
+}
+
+impl Drop for UdpSocket {
+    fn drop(&mut self) {
+        unsafe { host::api::networking::drop_udp_socket(self.id) };
+    }
+}
+
+impl UdpSocket {
+    /// Creates a new [`UdpSocket`] bound to the given address.
+    ///
+    /// Binding with a port number of 0 will request that the operating system assigns an available
+    /// port to this listener.
+    ///
+    /// If `addr` yields multiple addresses, binding will be attempted with each of the addresses
+    /// until one succeeds and returns the listener. If none of the addresses succeed in creating a
+    /// listener, the error from the last attempt is returned.
+    pub fn bind<A>(addr: A) -> Result<Self>
+    where
+        A: super::ToSocketAddrs,
+    {
+        let mut id = 0;
+        for addr in addr.to_socket_addrs()? {
+            let result = match addr {
+                SocketAddr::V4(v4_addr) => {
+                    let ip = v4_addr.ip().octets();
+                    let port = v4_addr.port() as u32;
+                    unsafe {
+                        host::api::networking::udp_bind(
+                            4,
+                            ip.as_ptr(),
+                            port,
+                            0,
+                            0,
+                            &mut id as *mut u64,
+                        )
+                    }
+                }
+                SocketAddr::V6(v6_addr) => {
+                    let ip = v6_addr.ip().octets();
+                    let port = v6_addr.port() as u32;
+                    let flow_info = v6_addr.flowinfo();
+                    let scope_id = v6_addr.scope_id();
+                    unsafe {
+                        host::api::networking::tcp_bind(
+                            6,
+                            ip.as_ptr(),
+                            port,
+                            flow_info,
+                            scope_id,
+                            &mut id as *mut u64,
+                        )
+                    }
+                }
+            };
+            if result == 0 {
+                return Ok(Self { id });
+            }
+        }
+        let lunatic_error = LunaticError::from(id);
+        Err(Error::new(ErrorKind::Other, lunatic_error))
+    }
+    /// Returns the local address that this UdpSocket is bound to.
+    ///
+    /// This can be useful, for example, to identify when binding to port 0 which port was assigned by the OS.
+    pub fn local_addr(&self) -> Result<SocketAddr> {
+        let mut dns_iter_or_error_id = 0;
+        let result = unsafe {
+            host::api::networking::udp_local_addr(self.id, &mut dns_iter_or_error_id as *mut u64)
+        };
+        if result == 0 {
+            let mut dns_iter = SocketAddrIterator::from(dns_iter_or_error_id);
+            let addr = dns_iter.next().expect("must contain one element");
+            Ok(addr)
+        } else {
+            let lunatic_error = LunaticError::from(dns_iter_or_error_id);
+            Err(Error::new(ErrorKind::Other, lunatic_error))
+        }
+    }
+}


### PR DESCRIPTION
I didn't see tests for TcpStream / TcpListener - what is the preference to drive this ?

- I plumbed the initial UdpSocket bind() local_addr() - this was the easy part

- Next up: connect, recv, recv_from, send, send_to, ...

I am hitting a test failure for some reason with something else atm
```
    Running tests/process.rs (target/wasm32-wasi/debug/deps/process-d3253ea88cbebc0d.wasm)
Error: unknown import: `lunatic::process::kill` has not been defined
error: test failed, to rerun pass '--test process'
```


TODO candidates from std::net::UdpSocket
- [X] pub fn [bind](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.bind)<A: [ToSocketAddrs](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html)>(addr: A) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)>
- [ ] pub fn [recv_from](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.recv_from)(&self, buf: [&mut [](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[(](https://doc.rust-lang.org/std/primitive.tuple.html)[usize](https://doc.rust-lang.org/std/primitive.usize.html), [SocketAddr](https://doc.rust-lang.org/std/net/enum.SocketAddr.html)[)](https://doc.rust-lang.org/std/primitive.tuple.html)>
- [ ]  pub fn [peek_from](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.peek_from)(&self, buf: [&mut [](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[(](https://doc.rust-lang.org/std/primitive.tuple.html)[usize](https://doc.rust-lang.org/std/primitive.usize.html), [SocketAddr](https://doc.rust-lang.org/std/net/enum.SocketAddr.html)[)](https://doc.rust-lang.org/std/primitive.tuple.html)>
- [ ] pub fn [send_to](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.send_to)<A: [ToSocketAddrs](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html)>(&self, buf: [&[](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html), addr: A) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[usize](https://doc.rust-lang.org/std/primitive.usize.html)>
- [ ] pub fn [peer_addr](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.peer_addr)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[SocketAddr](https://doc.rust-lang.org/std/net/enum.SocketAddr.html)>
- [X] pub fn [local_addr](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.local_addr)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[SocketAddr](https://doc.rust-lang.org/std/net/enum.SocketAddr.html)>
- [ ] pub fn [try_clone](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.try_clone)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)>
- [ ] pub fn [set_read_timeout](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_read_timeout)(&self, dur: [Option](https://doc.rust-lang.org/std/option/enum.Option.html)<[Duration](https://doc.rust-lang.org/std/time/struct.Duration.html)>) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [set_write_timeout](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_write_timeout)(&self, dur: [Option](https://doc.rust-lang.org/std/option/enum.Option.html)<[Duration](https://doc.rust-lang.org/std/time/struct.Duration.html)>) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [read_timeout](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.read_timeout)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[Option](https://doc.rust-lang.org/std/option/enum.Option.html)<[Duration](https://doc.rust-lang.org/std/time/struct.Duration.html)>>
- [ ] pub fn [write_timeout](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.write_timeout)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[Option](https://doc.rust-lang.org/std/option/enum.Option.html)<[Duration](https://doc.rust-lang.org/std/time/struct.Duration.html)>>
- [ ] pub fn [set_broadcast](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_broadcast)(&self, broadcast: [bool](https://doc.rust-lang.org/std/primitive.bool.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [broadcast](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.broadcast)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[bool](https://doc.rust-lang.org/std/primitive.bool.html)>
- [ ] pub fn [set_multicast_loop_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_loop_v4)(&self, multicast_loop_v4: [bool](https://doc.rust-lang.org/std/primitive.bool.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [multicast_loop_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_loop_v4)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[bool](https://doc.rust-lang.org/std/primitive.bool.html)>
- [ ] pub fn [set_multicast_ttl_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_ttl_v4)(&self, multicast_ttl_v4: [u32](https://doc.rust-lang.org/std/primitive.u32.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [multicast_ttl_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_ttl_v4)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[u32](https://doc.rust-lang.org/std/primitive.u32.html)>
- [ ] pub fn [set_multicast_loop_v6](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_loop_v6)(&self, multicast_loop_v6: [bool](https://doc.rust-lang.org/std/primitive.bool.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [multicast_loop_v6](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_loop_v6)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[bool](https://doc.rust-lang.org/std/primitive.bool.html)>
- [ ] pub fn [set_ttl](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_ttl)(&self, ttl: [u32](https://doc.rust-lang.org/std/primitive.u32.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [ttl](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.ttl)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[u32](https://doc.rust-lang.org/std/primitive.u32.html)>
- [ ] pub fn [join_multicast_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.join_multicast_v4)(..) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [join_multicast_v6](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.join_multicast_v6)(..) -> [Result]
- [ ] pub fn [leave_multicast_v4](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.leave_multicast_v4)(..) -> [Result]
- [ ] pub fn [leave_multicast_v6](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.leave_multicast_v6)(..) -> [Result]
- [ ] pub fn [take_error](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.take_error)(&self) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[Option](https://doc.rust-lang.org/std/option/enum.Option.html)<[Error](https://doc.rust-lang.org/std/io/struct.Error.html)>>
- [ ] pub fn [connect](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.connect)<A: [ToSocketAddrs](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html)>(&self, addr: A) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] pub fn [send](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.send)(&self, buf: [&[](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[usize](https://doc.rust-lang.org/std/primitive.usize.html)>
- [ ] pub fn [recv](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.recv)(&self, buf: [&mut [](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[usize](https://doc.rust-lang.org/std/primitive.usize.html)>
- [ ] pub fn [peek](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.peek)(&self, buf: [&mut [](https://doc.rust-lang.org/std/primitive.slice.html)[u8](https://doc.rust-lang.org/std/primitive.u8.html)[]](https://doc.rust-lang.org/std/primitive.slice.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[usize](https://doc.rust-lang.org/std/primitive.usize.html)>
- [ ] pub fn [set_nonblocking](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_nonblocking)(&self, nonblocking: [bool](https://doc.rust-lang.org/std/primitive.bool.html)) -> [Result](https://doc.rust-lang.org/std/io/type.Result.html)<[()](https://doc.rust-lang.org/std/primitive.unit.html)>
- [ ] impl [AsFd](https://doc.rust-lang.org/std/os/unix/io/trait.AsFd.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [AsRawFd](https://doc.rust-lang.org/std/os/unix/io/trait.AsRawFd.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [AsRawSocket](https://doc.rust-lang.org/std/os/windows/io/trait.AsRawSocket.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [AsSocket](https://doc.rust-lang.org/std/os/windows/io/trait.AsSocket.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [From](https://doc.rust-lang.org/std/convert/trait.From.html)<[OwnedFd](https://doc.rust-lang.org/std/os/unix/io/struct.OwnedFd.html)> for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [From](https://doc.rust-lang.org/std/convert/trait.From.html)<[OwnedSocket](https://doc.rust-lang.org/std/os/windows/io/struct.OwnedSocket.html)> for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [From](https://doc.rust-lang.org/std/convert/trait.From.html)<[UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)> for [OwnedSocket](https://doc.rust-lang.org/std/os/windows/io/struct.OwnedSocket.html)
- [ ] impl [From](https://doc.rust-lang.org/std/convert/trait.From.html)<[UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)> for [OwnedFd](https://doc.rust-lang.org/std/os/unix/io/struct.OwnedFd.html)
- [ ] impl [FromRawFd](https://doc.rust-lang.org/std/os/unix/io/trait.FromRawFd.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [FromRawSocket](https://doc.rust-lang.org/std/os/windows/io/trait.FromRawSocket.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [IntoRawFd](https://doc.rust-lang.org/std/os/unix/io/trait.IntoRawFd.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
- [ ] impl [IntoRawSocket](https://doc.rust-lang.org/std/os/windows/io/trait.IntoRawSocket.html) for [UdpSocket](https://doc.rust-lang.org/std/net/struct.UdpSocket.html)
